### PR TITLE
`Added ShrinkTests module` and  `All shrink tests run 1 million times`

### DIFF
--- a/src/Hedgehog.Experimental.Tests/GenTests.fs
+++ b/src/Hedgehog.Experimental.Tests/GenTests.fs
@@ -709,6 +709,16 @@ let ``auto uses specified overrides`` () =
 
 
 module ShrinkTests =
+
+  // We need to hit an error case in order to test shrinking. That error case may be uncommon.
+  // We therefore run 1 million tests to increase the probability of hitting an error case.
+  let render property =
+    let config =
+      PropertyConfig.defaultConfig
+      |> PropertyConfig.withTests 1_000_000<tests>
+    Property.reportWith config property
+    |> Report.render
+
   type MyRecord =
     { String: string
       Int: int }
@@ -719,8 +729,7 @@ module ShrinkTests =
       let! value = GenX.auto<MyRecord>
       test <@ not (value.String.Contains('b')) @>
     }
-    let report = Property.report property
-    let rendered = Report.render report
+    let rendered = render property
     test <@ rendered.Contains "{String = \"b\";\n Int = 0;}" @>
 
 
@@ -742,11 +751,7 @@ module ShrinkTests =
       let! value = GenX.auto<MyCliMutable>
       test <@ not (value.String.Contains('b')) @>
     }
-    let config =
-      PropertyConfig.defaultConfig
-      |> PropertyConfig.withTests 1_000_000<tests>
-    let report = Property.reportWith config property
-    let rendered = Report.render report
+    let rendered = render property
     test <@ rendered.Contains "String = b; Int = 0" @>
 
 
@@ -760,8 +765,7 @@ module ShrinkTests =
       let! MyDu.Case1(s, i) = GenX.auto<MyDu>
       test <@ not (s.Contains('b')) @>
     }
-    let report = Property.report property
-    let rendered = Report.render report
+    let rendered = render property
     test <@ rendered.Contains "Case1 (\"b\",0)" @>
 
 
@@ -771,8 +775,7 @@ module ShrinkTests =
       let! (s, _) = GenX.auto<string * int>
       test <@ not (s.Contains('b')) @>
     }
-    let report = Property.report property
-    let rendered = Report.render report
+    let rendered = render property
     test <@ rendered.Contains "(\"b\", 0)" @>
 
   [<Fact>]
@@ -781,8 +784,7 @@ module ShrinkTests =
       let! value = GenX.shuffleCase "abcdefg"
       test <@ not (value.StartsWith "A") @>
     }
-    let report = Property.report property
-    let rendered = Report.render report
+    let rendered = render property
     test <@ rendered.Contains "\"Abcdefg\"" @>
 
   [<Fact>]
@@ -798,8 +800,7 @@ module ShrinkTests =
         |> GenX.shuffle
       test <@ nMinus1 <> value.Head @>
     }
-    let report = Property.report property
-    let rendered = Report.render report
+    let rendered = render property
     test <@ rendered.Contains "[9; 0; 1; 2; 3; 4; 5; 6; 7; 8]" @>
 
   [<Fact>]
@@ -808,8 +809,7 @@ module ShrinkTests =
       let! array = GenX.auto<int []>
       test <@ array.Length = 0 @>
     }
-    let report = Property.report property
-    let rendered = Report.render report
+    let rendered = render property
     test <@ rendered.Contains "[|0|]" @>
 
   [<Fact>]
@@ -820,11 +820,7 @@ module ShrinkTests =
         |> GenX.autoWith<int []>
       test <@ 1 <> array.[0] @>
     }
-    let config =
-      PropertyConfig.defaultConfig
-      |> PropertyConfig.withTests 1_000_000<tests>
-    let report = Property.reportWith config property
-    let rendered = Report.render report
+    let rendered = render property
     test <@ rendered.Contains "[|1; 0" @>
 
   [<Fact>]
@@ -833,8 +829,7 @@ module ShrinkTests =
       let! array = GenX.auto<int [,]>
       test <@ array.Length = 0 @>
     }
-    let report = Property.report property
-    let rendered = Report.render report
+    let rendered = render property
     test <@ rendered.Contains "[[0]]" @>
 
   [<Fact>]
@@ -845,11 +840,7 @@ module ShrinkTests =
         |> GenX.autoWith<int [,]>
       test <@ 1 <> array.[0,0] @>
     }
-    let config =
-      PropertyConfig.defaultConfig
-      |> PropertyConfig.withTests 1_000_000<tests>
-    let report = Property.reportWith config property
-    let rendered = Report.render report
+    let rendered = render property
     test <@ rendered.Contains "[[1; 0" ||
             rendered.Contains "[[1]\n [0]" ||
             rendered.Contains "[[1]]"@>

--- a/src/Hedgehog.Experimental.Tests/GenTests.fs
+++ b/src/Hedgehog.Experimental.Tests/GenTests.fs
@@ -708,150 +708,151 @@ let ``auto uses specified overrides`` () =
   }
 
 
-type MyRecord =
-  { String: string
-    Int: int }
+module ShrinkTests =
+  type MyRecord =
+    { String: string
+      Int: int }
 
-[<Fact>]
-let ``auto of record shrinks correctly`` () =
-  let property = property {
-    let! value = GenX.auto<MyRecord>
-    test <@ not (value.String.Contains('b')) @>
-  }
-  let report = Property.report property
-  let rendered = Report.render report
-  test <@ rendered.Contains "{String = \"b\";\n Int = 0;}" @>
-
-
-type MyCliMutable() =
-  let mutable myString = ""
-  let mutable myInt = 0
-  member _.String
-    with get () = myString
-    and set value = myString <- value
-  member _.Int
-    with get () = myInt
-    and set value = myInt <- value
-  override _.ToString() =
-    "String = " + myString + "; Int = " + myInt.ToString()
-
-[<Fact>]
-let ``auto of CLI mutable shrinks correctly`` () =
-  let property = property {
-    let! value = GenX.auto<MyCliMutable>
-    test <@ not (value.String.Contains('b')) @>
-  }
-  let config =
-    PropertyConfig.defaultConfig
-    |> PropertyConfig.withTests 1_000_000<tests>
-  let report = Property.reportWith config property
-  let rendered = Report.render report
-  test <@ rendered.Contains "String = b; Int = 0" @>
+  [<Fact>]
+  let ``auto of record shrinks correctly`` () =
+    let property = property {
+      let! value = GenX.auto<MyRecord>
+      test <@ not (value.String.Contains('b')) @>
+    }
+    let report = Property.report property
+    let rendered = Report.render report
+    test <@ rendered.Contains "{String = \"b\";\n Int = 0;}" @>
 
 
-[<RequireQualifiedAccess>]
-type MyDu =
-  | Case1 of String * int
+  type MyCliMutable() =
+    let mutable myString = ""
+    let mutable myInt = 0
+    member _.String
+      with get () = myString
+      and set value = myString <- value
+    member _.Int
+      with get () = myInt
+      and set value = myInt <- value
+    override _.ToString() =
+      "String = " + myString + "; Int = " + myInt.ToString()
 
-[<Fact>]
-let ``auto of discriminated union shrinks correctly`` () =
-  let property = property {
-    let! MyDu.Case1(s, i) = GenX.auto<MyDu>
-    test <@ not (s.Contains('b')) @>
-  }
-  let report = Property.report property
-  let rendered = Report.render report
-  test <@ rendered.Contains "Case1 (\"b\",0)" @>
+  [<Fact>]
+  let ``auto of CLI mutable shrinks correctly`` () =
+    let property = property {
+      let! value = GenX.auto<MyCliMutable>
+      test <@ not (value.String.Contains('b')) @>
+    }
+    let config =
+      PropertyConfig.defaultConfig
+      |> PropertyConfig.withTests 1_000_000<tests>
+    let report = Property.reportWith config property
+    let rendered = Report.render report
+    test <@ rendered.Contains "String = b; Int = 0" @>
 
 
-[<Fact>]
-let ``auto of tuple shrinks correctly`` () =
-  let property = property {
-    let! (s, _) = GenX.auto<string * int>
-    test <@ not (s.Contains('b')) @>
-  }
-  let report = Property.report property
-  let rendered = Report.render report
-  test <@ rendered.Contains "(\"b\", 0)" @>
+  [<RequireQualifiedAccess>]
+  type MyDu =
+    | Case1 of String * int
 
-[<Fact>]
-let ``shuffleCase shrinks correctly`` () =
-  let property = property {
-    let! value = GenX.shuffleCase "abcdefg"
-    test <@ not (value.StartsWith "A") @>
-  }
-  let report = Property.report property
-  let rendered = Report.render report
-  test <@ rendered.Contains "\"Abcdefg\"" @>
+  [<Fact>]
+  let ``auto of discriminated union shrinks correctly`` () =
+    let property = property {
+      let! MyDu.Case1(s, i) = GenX.auto<MyDu>
+      test <@ not (s.Contains('b')) @>
+    }
+    let report = Property.report property
+    let rendered = Report.render report
+    test <@ rendered.Contains "Case1 (\"b\",0)" @>
 
-[<Fact>]
-let ``shuffle shrinks correctly`` () =
-  let property = property {
-    let n = 10
-    let nMinus1 = n - 1
-    let! value =
-      ()
-      |> Seq.replicate n
-      |> Seq.mapi (fun i _ -> i)
-      |> Seq.toList
-      |> GenX.shuffle
-    test <@ nMinus1 <> value.Head @>
-  }
-  let report = Property.report property
-  let rendered = Report.render report
-  test <@ rendered.Contains "[9; 0; 1; 2; 3; 4; 5; 6; 7; 8]" @>
 
-[<Fact>]
-let ``one-dimentional array shrinks correctly when empty allowed`` () =
-  let property = property {
-    let! array = GenX.auto<int []>
-    test <@ array.Length = 0 @>
-  }
-  let report = Property.report property
-  let rendered = Report.render report
-  test <@ rendered.Contains "[|0|]" @>
+  [<Fact>]
+  let ``auto of tuple shrinks correctly`` () =
+    let property = property {
+      let! (s, _) = GenX.auto<string * int>
+      test <@ not (s.Contains('b')) @>
+    }
+    let report = Property.report property
+    let rendered = Report.render report
+    test <@ rendered.Contains "(\"b\", 0)" @>
 
-[<Fact>]
-let ``one-dimentional array shrinks correctly when empty disallowed`` () =
-  let property = property {
-    let! array =
-      { GenX.defaults with SeqRange = Range.constant 2 5 }
-      |> GenX.autoWith<int []>
-    test <@ 1 <> array.[0] @>
-  }
-  let config =
-    PropertyConfig.defaultConfig
-    |> PropertyConfig.withTests 1_000_000<tests>
-  let report = Property.reportWith config property
-  let rendered = Report.render report
-  test <@ rendered.Contains "[|1; 0" @>
+  [<Fact>]
+  let ``shuffleCase shrinks correctly`` () =
+    let property = property {
+      let! value = GenX.shuffleCase "abcdefg"
+      test <@ not (value.StartsWith "A") @>
+    }
+    let report = Property.report property
+    let rendered = Report.render report
+    test <@ rendered.Contains "\"Abcdefg\"" @>
 
-[<Fact>]
-let ``two-dimentional array shrinks correctly when empty allowed`` () =
-  let property = property {
-    let! array = GenX.auto<int [,]>
-    test <@ array.Length = 0 @>
-  }
-  let report = Property.report property
-  let rendered = Report.render report
-  test <@ rendered.Contains "[[0]]" @>
+  [<Fact>]
+  let ``shuffle shrinks correctly`` () =
+    let property = property {
+      let n = 10
+      let nMinus1 = n - 1
+      let! value =
+        ()
+        |> Seq.replicate n
+        |> Seq.mapi (fun i _ -> i)
+        |> Seq.toList
+        |> GenX.shuffle
+      test <@ nMinus1 <> value.Head @>
+    }
+    let report = Property.report property
+    let rendered = Report.render report
+    test <@ rendered.Contains "[9; 0; 1; 2; 3; 4; 5; 6; 7; 8]" @>
 
-[<Fact>]
-let ``two-dimentional array shrinks correctly when empty disallowed`` () =
-  let property = property {
-    let! array =
-      { GenX.defaults with SeqRange = Range.constant 1 5 }
-      |> GenX.autoWith<int [,]>
-    test <@ 1 <> array.[0,0] @>
-  }
-  let config =
-    PropertyConfig.defaultConfig
-    |> PropertyConfig.withTests 1_000_000<tests>
-  let report = Property.reportWith config property
-  let rendered = Report.render report
-  test <@ rendered.Contains "[[1; 0" ||
-          rendered.Contains "[[1]\n [0]" ||
-          rendered.Contains "[[1]]"@>
+  [<Fact>]
+  let ``one-dimentional array shrinks correctly when empty allowed`` () =
+    let property = property {
+      let! array = GenX.auto<int []>
+      test <@ array.Length = 0 @>
+    }
+    let report = Property.report property
+    let rendered = Report.render report
+    test <@ rendered.Contains "[|0|]" @>
+
+  [<Fact>]
+  let ``one-dimentional array shrinks correctly when empty disallowed`` () =
+    let property = property {
+      let! array =
+        { GenX.defaults with SeqRange = Range.constant 2 5 }
+        |> GenX.autoWith<int []>
+      test <@ 1 <> array.[0] @>
+    }
+    let config =
+      PropertyConfig.defaultConfig
+      |> PropertyConfig.withTests 1_000_000<tests>
+    let report = Property.reportWith config property
+    let rendered = Report.render report
+    test <@ rendered.Contains "[|1; 0" @>
+
+  [<Fact>]
+  let ``two-dimentional array shrinks correctly when empty allowed`` () =
+    let property = property {
+      let! array = GenX.auto<int [,]>
+      test <@ array.Length = 0 @>
+    }
+    let report = Property.report property
+    let rendered = Report.render report
+    test <@ rendered.Contains "[[0]]" @>
+
+  [<Fact>]
+  let ``two-dimentional array shrinks correctly when empty disallowed`` () =
+    let property = property {
+      let! array =
+        { GenX.defaults with SeqRange = Range.constant 1 5 }
+        |> GenX.autoWith<int [,]>
+      test <@ 1 <> array.[0,0] @>
+    }
+    let config =
+      PropertyConfig.defaultConfig
+      |> PropertyConfig.withTests 1_000_000<tests>
+    let report = Property.reportWith config property
+    let rendered = Report.render report
+    test <@ rendered.Contains "[[1; 0" ||
+            rendered.Contains "[[1]\n [0]" ||
+            rendered.Contains "[[1]]"@>
 
 [<Fact>]
 let ``MultidimensionalArray.createWithGivenEntries works for 2x2`` () =


### PR DESCRIPTION
I can pretty easily run 100 tests without hitting `b`, so I feel like _all_ shrink tests should just run 1 million times. Perhaps some tests don't need it, but I don't see the point of thinking about it.

![image](https://user-images.githubusercontent.com/1278803/132244416-2c39790f-9c89-4ed9-a857-9083a5f3f19b.png)

Extracted stuff into `ShrinkModule` to scope the `render`. I feel like it could also be its own file, but I'm erring on the side of conservatism.